### PR TITLE
CDP-702 Add embed code for posts

### DIFF
--- a/src/components/Share/Share.js
+++ b/src/components/Share/Share.js
@@ -9,11 +9,12 @@ import './Share.css';
 
 const Share = ( props ) => {
   const {
-    id, site, language, title, link
+    id, site, language, title, link, type
   } = props;
 
+  const contentType = type;
   const queryStr = stringifyQueryString( { id, site, language } );
-  const directLink = `${window.location.protocol}//${window.location.host}/video?${queryStr}`;
+  const directLink = `${window.location.protocol}//${window.location.host}/${contentType}?${queryStr}`;
   const facebookURL = `https://www.facebook.com/sharer/sharer.php?u=${link}`;
   const tweet = `https://twitter.com/home?status=${title} ${link}`;
 
@@ -35,7 +36,8 @@ Share.propTypes = {
   site: string,
   language: string,
   link: string,
-  title: string
+  title: string,
+  type: string
 };
 
 export default Share;

--- a/src/components/Share/Share.js
+++ b/src/components/Share/Share.js
@@ -12,9 +12,8 @@ const Share = ( props ) => {
     id, site, language, title, link, type
   } = props;
 
-  const contentType = type;
   const queryStr = stringifyQueryString( { id, site, language } );
-  const directLink = `${window.location.protocol}//${window.location.host}/${contentType}?${queryStr}`;
+  const directLink = ( type === 'video' ) ? `${window.location.protocol}//${window.location.host}/video?${queryStr}` : link;
   const facebookURL = `https://www.facebook.com/sharer/sharer.php?u=${link}`;
   const tweet = `https://twitter.com/home?status=${title} ${link}`;
 

--- a/src/components/Types/Post/EmbedPost.js
+++ b/src/components/Types/Post/EmbedPost.js
@@ -12,7 +12,7 @@ const embedPopupStyles = {
 
 const PostEmbed = props => (
   <div>
-    <Embed instructions={ props.instructions }>
+    <Embed instructions={ props.instructions } embedItem={ props.embedItem }>
       <Checkbox className="embed_keepStyles" label="Maintain original page styling" />
       <Popup
         trigger={ <Icon name="info circle" className="embed_tooltip" /> }
@@ -27,6 +27,7 @@ const PostEmbed = props => (
 );
 
 PostEmbed.propTypes = {
+  embedItem: string,
   instructions: string
 };
 

--- a/src/components/Types/Post/EmbedPost.js
+++ b/src/components/Types/Post/EmbedPost.js
@@ -13,7 +13,7 @@ const embedPopupStyles = {
 const PostEmbed = props => (
   <div>
     <Embed instructions={ props.instructions } embedItem={ props.embedItem }>
-      <Checkbox className="embed_keepStyles" label="Maintain original page styling" />
+      { /* <Checkbox className="embed_keepStyles" label="Maintain original page styling" />
       <Popup
         trigger={ <Icon name="info circle" className="embed_tooltip" /> }
         content="Check the box to embed this article with its original styling from the source site.
@@ -21,7 +21,7 @@ const PostEmbed = props => (
         position="bottom center"
         style={ embedPopupStyles }
         className="embed_popup"
-      />
+      /> */ }
     </Embed>
   </div>
 );

--- a/src/components/Types/Post/Post.js
+++ b/src/components/Types/Post/Post.js
@@ -17,7 +17,7 @@ import PopupTrigger from '../../Popup/PopupTrigger';
 import PopupTabbed from '../../Popup/PopupTabbed';
 import Popup from '../../Popup/Popup';
 
-// import Share from '../../Share/Share';
+import Share from '../../Share/Share';
 import EmbedPost from './EmbedPost';
 import EmbedHelp from './EmbedHelp';
 
@@ -62,6 +62,13 @@ class Post extends Component {
   render() {
     if ( this.state && this.state.item ) {
       const { item, textDirection } = this.state;
+      const embedItem = (
+        `<script src="https://iipdesignmodules.america.gov/modules/cdp-module-article-single/static/js/iframe-resizer-host.min.js"></script>
+        <iframe id="cdp-article" width="100%" src="https://iipdesignmodules.america.gov/modules/cdp-module-article-single/index.html?id=${item.id}&site=${item.site}" frameborder="0" scrolling="no">
+        </iframe>
+        <script>iFrameResize({heightCalculationMethod:'bodyScroll'}, '#cdp-article')</script>`
+      );
+
       return (
         <ModalItem headline={ item.title } textDirection={ textDirection }>
           <div className="modal_options">
@@ -72,7 +79,7 @@ class Post extends Component {
                 handleLanguageChange={ this.handleLanguageChange }
               />
             </div>
-            <div className="trigger-container" style={ { display: 'none' } }>
+            <div className="trigger-container">
               <PopupTrigger
                 toolTip="Embed this article."
                 icon={ { img: embedIcon, dim: 24 } }
@@ -86,7 +93,7 @@ class Post extends Component {
                         component: (
                           <EmbedPost
                             instructions="Copy and paste the code below to embed article on your site"
-                            embedItem={ item }
+                            embedItem={ embedItem }
                           />
                         )
                       },
@@ -101,13 +108,14 @@ class Post extends Component {
                 show
                 content={
                   <Popup title="Share this article.">
-                    { /* <Share
-                      link={ shareLink }
-                      id={ id }
-                      site={ site }
-                      title={ unit.title }
-                      language={ selectedLanguage.locale }
-                    /> */ }
+                    <Share
+                      id={ item.id }
+                      language={ item.language.locale }
+                      link={ item.link }
+                      site={ item.site }
+                      title={ item.title }
+                      type={ item.type }
+                    />
                   </Popup>
                 }
               />

--- a/src/components/Types/Post/Post.js
+++ b/src/components/Types/Post/Post.js
@@ -64,8 +64,7 @@ class Post extends Component {
       const { item, textDirection } = this.state;
       const embedItem = (
         `<div id="cdp-article-embed"></div>
-        <script async id="cdpArticle" data-id="${item.id}" data-site="${item.site}" src="${process.env.REACT_APP_MODULES_URL}/cdp-module-article-single/cdp-module-loader.min.js"></script>
-        `
+        <script async id="cdpArticle" data-id="${item.id}" data-site="${item.site}" src="${process.env.REACT_APP_MODULES_URL}cdp-module-article-single/cdp-module-loader.min.js"></script>`
       );
 
       return (

--- a/src/components/Types/Post/Post.js
+++ b/src/components/Types/Post/Post.js
@@ -63,10 +63,9 @@ class Post extends Component {
     if ( this.state && this.state.item ) {
       const { item, textDirection } = this.state;
       const embedItem = (
-        `<script src="https://iipdesignmodules.america.gov/modules/cdp-module-article-single/static/js/iframe-resizer-host.min.js"></script>
-        <iframe id="cdp-article" width="100%" src="https://iipdesignmodules.america.gov/modules/cdp-module-article-single/index.html?id=${item.id}&site=${item.site}" frameborder="0" scrolling="no">
-        </iframe>
-        <script>iFrameResize({heightCalculationMethod:'bodyScroll'}, '#cdp-article')</script>`
+        `<div id="cdp-article-embed"></div>
+        <script async id="cdpArticle" data-id="${item.id}" data-site="${item.site}" src="${process.env.REACT_APP_MODULES_URL}/cdp-module-article-single/cdp-module-loader.min.js"></script>
+        `
       );
 
       return (

--- a/src/components/Types/Post/Post.js
+++ b/src/components/Types/Post/Post.js
@@ -64,7 +64,7 @@ class Post extends Component {
       const { item, textDirection } = this.state;
       const embedItem = (
         `<div id="cdp-article-embed"></div>
-        <script async id="cdpArticle" data-id="${item.id}" data-site="${item.site}" src="${process.env.REACT_APP_MODULES_URL}cdp-module-article-single/cdp-module-loader.min.js"></script>`
+        <script async id="cdpArticle" data-id="${item.id}" data-site="${item.site}" src="${process.env.REACT_APP_CDP_MODULES_URL}cdp-module-article-single/cdp-module-loader.min.js"></script>`
       );
 
       return (
@@ -95,7 +95,7 @@ class Post extends Component {
                           />
                         )
                       },
-                      { title: 'Help', component: <EmbedHelp /> }
+                      // { title: 'Help', component: <EmbedHelp /> }
                     ] }
                   />
                 }

--- a/src/components/Types/Video/Video.js
+++ b/src/components/Types/Video/Video.js
@@ -381,6 +381,7 @@ class Video extends Component {
                       site={ site }
                       title={ unit.title }
                       language={ selectedLanguage.locale }
+                      type={ this.props.item.type }
                     />
                   </Popup>
                 }


### PR DESCRIPTION
- Adds embed code for single article module
- Reactivate share button on post
- Checks post type to generate correct share link

NOTE: The embed code points to the production build of the article module. Ideally, it would adjust which module it pulls depending on the environment (i.e. commons.dev uses an embed code for the dev build of the single article module). I wasn't sure how to do this other than by using environmental variables so I held off on implementing a solution.