### PR TITLE
Refactor about, contact, and help pages

### DIFF
--- a/src/components/Pages/AboutPage/AboutPage.js
+++ b/src/components/Pages/AboutPage/AboutPage.js
@@ -1,42 +1,60 @@
 import React, { Component } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { Header } from 'semantic-ui-react';
+import axios from 'axios';
+
 import Page from '../PageTmpl';
 import Breadcrumbs from '../../Breadcrumbs';
+
 import config from '../../../config';
 
 class AboutPage extends Component {
-  componentWillMount() {
-    const cachedAbout = sessionStorage.getItem( 'AboutPage' );
-    if ( cachedAbout ) {
-      this.setState( { markdown: cachedAbout } );
-      return;
-    }
-
-    fetch( config.ABOUT_URL )
-      .then( response => response.text() )
-      .then( text => this.onFetchResult( text ) );
+  constructor() {
+    super();
+    this.state = {
+      content: <div>Loading...</div>
+    };
   }
 
-  onFetchResult = ( text ) => {
-    sessionStorage.setItem( 'AboutPage', text );
+  componentDidMount() {
+    const cached = this.checkSessionStorage();
+    if ( !cached ) {
+      axios.get( config.ABOUT_URL )
+        .then( response => this.onFetchResult( response.data ), error => this.onError( error ) );
+    }
+  }
+
+  onFetchResult = ( result ) => {
+    sessionStorage.setItem( 'AboutPage', result );
     this.setState( {
-      markdown: text
+      content: <ReactMarkdown source={ result } />
     } );
   }
 
-  render() {
-    if ( this.state ) {
-      const { markdown } = this.state;
-      return (
-        <Page>
-          <Breadcrumbs />
-          <Header as="h1">About Content Commons</Header>
-          <ReactMarkdown source={ markdown } />
-        </Page>
-      );
+  onError = ( error ) => {
+    this.setState( {
+      content: config.ERROR_MESSAGE
+    } );
+  }
+
+  checkSessionStorage() {
+    const cachedAbout = sessionStorage.getItem( 'AboutPage' );
+    if ( cachedAbout ) {
+      this.setState( { content: <ReactMarkdown source={ cachedAbout } /> } );
+      return true;
     }
-    return <div />;
+    return false;
+  }
+
+  render() {
+    const { content } = this.state;
+    return (
+      <Page>
+        <Breadcrumbs />
+        <Header as="h1">About Content Commons</Header>
+        { content }
+      </Page>
+    );
   }
 }
 

--- a/src/components/Pages/ContactPage/ContactPage.js
+++ b/src/components/Pages/ContactPage/ContactPage.js
@@ -1,42 +1,60 @@
 import React, { Component } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { Header } from 'semantic-ui-react';
+import axios from 'axios';
+
 import Page from '../PageTmpl';
 import Breadcrumbs from '../../Breadcrumbs';
+
 import config from '../../../config';
 
 class ContactPage extends Component {
-  componentWillMount() {
-    const cachedContact = sessionStorage.getItem( 'ContactPage' );
-    if ( cachedContact ) {
-      this.setState( { markdown: cachedContact } );
-      return;
-    }
-
-    fetch( config.CONTACT_URL )
-      .then( response => response.text() )
-      .then( text => this.onFetchResult( text ) );
+  constructor() {
+    super();
+    this.state = {
+      content: <div>Loading...</div>
+    };
   }
 
-  onFetchResult = ( text ) => {
-    sessionStorage.setItem( 'ContactPage', text );
+  componentDidMount() {
+    const cached = this.checkSessionStorage();
+    if ( !cached ) {
+      axios.get( config.CONTACT_URL )
+        .then( response => this.onFetchResult( response.data ), error => this.onError( error ) );
+    }
+  }
+
+  onFetchResult = ( result ) => {
+    sessionStorage.setItem( 'ContactPage', result );
     this.setState( {
-      markdown: text
+      content: <ReactMarkdown source={ result } />
     } );
   }
 
-  render() {
-    if ( this.state ) {
-      const { markdown } = this.state;
-      return (
-        <Page>
-          <Breadcrumbs />
-          <Header as="h1">Contact Us</Header>
-          <ReactMarkdown source={ markdown } />
-        </Page>
-      );
+  onError = ( error ) => {
+    this.setState( {
+      content: config.ERROR_MESSAGE
+    } );
+  }
+
+  checkSessionStorage() {
+    const cachedContact = sessionStorage.getItem( 'ContactPage' );
+    if ( cachedContact ) {
+      this.setState( { content: <ReactMarkdown source={ cachedContact } /> } );
+      return true;
     }
-    return <div />;
+    return false;
+  }
+
+  render() {
+    const { content } = this.state;
+    return (
+      <Page>
+        <Breadcrumbs />
+        <Header as="h1">Contact Us</Header>
+        { content }
+      </Page>
+    );
   }
 }
 


### PR DESCRIPTION
Change About, Contact, and Help pages to match the privacy page. Namely:
- Add constructor
- Switch from fetch to Axios
- Add onError function to pull in error message
- Add check for cached page