### PR TITLE
Complete embed code integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ REACT_APP_WEBSITE_NAME=Content Commons
 #REACT_APP_PUBLIC_API=https://api.staging.america.gov (staging)
 REACT_APP_PUBLIC_API=https://api.america.gov (prod)
 
+# Points to the S3 bucket for CDP module (for the embed code)
+REACT_APP_CDP_MODULES_URL=
+
 # Value from YouTube
 REACT_APP_YOUTUBE_API_KEY=
 

--- a/client/src/components/Types/Post/EmbedPost.js
+++ b/client/src/components/Types/Post/EmbedPost.js
@@ -12,8 +12,8 @@ const embedPopupStyles = {
 
 const PostEmbed = props => (
   <div>
-    <Embed instructions={ props.instructions }>
-      <Checkbox className="embed_keepStyles" label="Maintain original page styling" />
+    <Embed instructions={ props.instructions } embedItem={ props.embedItem }>
+      { /* <Checkbox className="embed_keepStyles" label="Maintain original page styling" />
       <Popup
         trigger={ <Icon name="info circle" className="embed_tooltip" /> }
         content="Check the box to embed this article with its original styling from the source site.
@@ -21,12 +21,13 @@ const PostEmbed = props => (
         position="bottom center"
         style={ embedPopupStyles }
         className="embed_popup"
-      />
+      /> */ }
     </Embed>
   </div>
 );
 
 PostEmbed.propTypes = {
+  embedItem: string,
   instructions: string
 };
 


### PR DESCRIPTION
Completes the port of the post embed code over to the v2 branch. Specifically:
- Adds the embed item as an embed prop
- Hides the 'keep original styles' checkbox
- Updates README to include env variable field for CDP module bucket
