### PR TITLE
CDP-825 - edit Loadable generator

### DIFF
--- a/client/generators/component/loadable.js.hbs
+++ b/client/generators/component/loadable.js.hbs
@@ -3,11 +3,11 @@
  * Asynchronously loads the component for {{ properCase name }}
  *
  */
-
+import React from 'react';
 import Loadable from 'react-loadable';
 import LoadingIndicator from 'components/LoadingIndicator'
 
 export default Loadable( {
   loader: () => import( './index' ),
-  loading: () => LoadingIndicator
+  loading: () => <LoadingIndicator />
 } );


### PR DESCRIPTION
- to include react and display indicator component
- fixes "Functions cannot be React Child.." error when creating loadable components