### PR TITLE
Set single article loader portion of embed URL in env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ REACT_APP_WEBSITE_NAME=Content Commons
 #REACT_APP_PUBLIC_API=https://api.staging.america.gov (staging)
 REACT_APP_PUBLIC_API=https://api.america.gov (prod)
 
-# Points to the S3 bucket for CDP module (for the embed code)
+# Point to the S3 bucket and objects for CDP modules (for the embed code) 
 REACT_APP_CDP_MODULES_URL=
+REACT_APP_SINGLE_ARTICLE_MODULE=
 
 # Value from YouTube
 REACT_APP_YOUTUBE_API_KEY=

--- a/client/src/components/Types/Post/Post.js
+++ b/client/src/components/Types/Post/Post.js
@@ -64,7 +64,7 @@ class Post extends Component {
       const { item, textDirection } = this.state;
       const embedItem = (
         `<div id="cdp-article-embed"></div>
-        <script async id="cdpArticle" data-id="${item.id}" data-site="${item.site}" src="${process.env.REACT_APP_CDP_MODULES_URL}cdp-module-article-single/cdp-module-loader.min.js"></script>`
+        <script async id="cdpArticle" data-id="${item.id}" data-site="${item.site}" src="${process.env.REACT_APP_CDP_MODULES_URL}${process.env.REACT_APP_SINGLE_ARTICLE_MODULE}"></script>`
       );
 
       return (


### PR DESCRIPTION
Ports over change from master which sets the full S3 url for article embeds via environmental variables.