### PR TITLE
CDP-835: Oversized Arrow Icon on Click of Video and SRT Tabs

### DIFF
--- a/src/components/Types/Video/Video.scss
+++ b/src/components/Types/Video/Video.scss
@@ -31,6 +31,24 @@
   }
 
 
+  @media only screen and (max-width: 767px) {
+    .ui.items.download-item > .item > .ui.mini.image,
+    .ui.items.download-item > .item > .ui.mini.image > img {
+      width: 20px !important;
+      margin-left: 0;
+      margin-right: 0;
+    }
+
+    .ui.items.download-item > .item {
+      flex-direction: row;
+    }
+
+    .ui.segment .ui.items.download-item .item .content {
+      padding: 0 0 0 1em !important;
+    }
+  }
+
+
   .ui.items > .item .meta {
     font-style: italic;
   }


### PR DESCRIPTION
Added CSS to overwrite the semantic CSS that messes up the arrow icon on small screens.

This also fixes CDP-847.

THIS WILL NOT MERGE INTO V2!