### PR TITLE
CDP-848: Close Icon Missing from Modals for Articles and Videos

### DIFF
--- a/src/components/Modals/ModalItem/ModalItem.scss
+++ b/src/components/Modals/ModalItem/ModalItem.scss
@@ -56,20 +56,6 @@
       left: auto;    
       color: #000;
     }
-    /* IE 10+ */
-    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-      top: 0 !important;
-      right: 15px !important;
-      left: auto;
-      color: #fff;
-      @media screen and (min-width: 1225px) {
-        right: 10% !important;
-      }
-      @media screen and (max-width: 1024px) {
-        top: 3px !important;
-        color: #000;
-      }
-    }
     /* IE Edge */
     @supports (-ms-ime-align: auto) {
       top: 0 !important;
@@ -82,6 +68,21 @@
       @media screen and (max-width: 1024px) {
         top: 3px !important;
         color: #000;
+      }
+    }
+  }
+
+  /* scrolling modal messes up close icon in IE and Edge */
+  &.ui.scrolling .close {
+    /* IE 10+ */
+    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+      @media only screen and (min-width: 992px) {
+        top: 3.5rem;
+        right: calc(50% - 425px + 0.25rem) !important;
+      }
+      @media only screen and (min-width: 1200px) {
+        top: 3.5rem;
+        right: calc(50% - 450px + 0.24rem) !important;
       }
     }
   }

--- a/src/components/Modals/ModalItem/ModalItem.scss
+++ b/src/components/Modals/ModalItem/ModalItem.scss
@@ -38,53 +38,13 @@
   }
 
   &.ui .close {    
-    top: 0;
-    right: 5px !important;
+    top: auto;
+    right: auto !important;
     left: auto;    
     color: #000;
     font-size: 2em;
-    @media only screen 
-    and (min-width: 768px)
-    and (max-width: 1024px)
-    and (orientation: landscape) {
-      position: relative !important;
-      float: right;
-    }
-    @media screen and (max-width: 1023px) {
-      top: -5px !important;
-      right: 5px !important;
-      left: auto;    
-      color: #000;
-    }
-    /* IE Edge */
-    @supports (-ms-ime-align: auto) {
-      top: 0 !important;
-      right: 15px !important;
-      left: auto;
-      color: #fff;
-      @media screen and (min-width: 1225px) {
-        right: 10% !important;
-      }
-      @media screen and (max-width: 1024px) {
-        top: 3px !important;
-        color: #000;
-      }
-    }
-  }
-
-  /* scrolling modal messes up close icon in IE and Edge */
-  &.ui.scrolling .close {
-    /* IE 10+ */
-    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-      @media only screen and (min-width: 992px) {
-        top: 3.5rem;
-        right: calc(50% - 425px + 0.25rem) !important;
-      }
-      @media only screen and (min-width: 1200px) {
-        top: 3.5rem;
-        right: calc(50% - 450px + 0.24rem) !important;
-      }
-    }
+    position: relative;
+    float: right;
   }
 
   &_section {


### PR DESCRIPTION
Removed old IE CSS that wasn't working.
Added right position of close icon for IE at certain breakpoints for proper positioning.