### PR TITLE
CDP-766 - ios mobile popup offclick close

### DIFF
--- a/src/components/Popup/PopupTrigger.js
+++ b/src/components/Popup/PopupTrigger.js
@@ -13,6 +13,13 @@ class PopupTrigger extends Component {
 
   componentDidMount() {
     this.isMobile();
+
+    // iOS can only trigger an onclick event if element has cursor:pointer
+    // adding style to Modal on iOS devices
+    if ( 'ontouchstart' in document.documentElement ) {
+      const activeModal = document.querySelector('.ui.modal');
+      activeModal.style.cursor = 'pointer';
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
- ios devices elements need style attr. 'cursor:pointer' in order to fire a click event
- added style to Modal when the share/embed/download popup mounts
- allows the Modal to be clickable so clicking off the popup, popup closes