### PR TITLE
CDP-1097: When you close the modal window, the url on the result page should include /results

### DIFF
--- a/src/components/Types/Video/Video.js
+++ b/src/components/Types/Video/Video.js
@@ -44,6 +44,7 @@ class Video extends Component {
       videoProps: null,
       shareLink: ''
     };
+    this.prevUrl = window.location.href;
   }
 
   /**
@@ -71,7 +72,7 @@ class Video extends Component {
   }
 
   componentWillUnmount() {
-    updateUrl( '/' );
+    updateUrl( this.prevUrl );
   }
 
   /**


### PR DESCRIPTION
Updated Video modal to return to the original URL when unmounted.