### PR TITLE
CDP-1125: Restrict display of video if missing content

### DIFF
--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -16,7 +16,7 @@ import {
   SEARCH_SORT_SUCCESS
 } from './types';
 import { queryRequest } from '../utils/api';
-import { queryBuilder } from '../utils/helpers';
+import { queryBuilder, filterResponse } from '../utils/helpers';
 
 const calculatePageOffset = ( currentPage, pageSize ) => {
   if ( currentPage < 0 ) {
@@ -115,7 +115,7 @@ export const createRequest = () => async ( dispatch, getState ) => {
   return dispatch( {
     type: SEARCH_REQUEST_SUCCESS,
     payload: {
-      response,
+      response: filterResponse( response, currentState.language.currentLanguage.key ),
       ...calculatePages( response.hits.total, 1, pageSize ), // currentPage
       pageSize,
       currentQuery: query

--- a/src/components/Recents/Recents.js
+++ b/src/components/Recents/Recents.js
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import * as actions from '../../actions';
 import './Recents.css';
 import { normalizeItem } from '../../utils/parser';
+import { filterResponse } from '../../utils/helpers';
 import ModalContent from '../Modals/ModalContent';
 
 class Recents extends Component {
@@ -16,7 +17,7 @@ class Recents extends Component {
     const currentLang = 'en-us';
     const response = await typeRecentsRequest( this.props.postType, currentLang );
     this.setState( {
-      recents: response
+      recents: filterResponse( response, currentLang )
     } );
   }
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -256,6 +256,36 @@ export const queryBuilder = ( store ) => {
   return body.build();
 };
 
+/**
+ * Removes videos from the ElasticSearch response that do not have streaming URLs
+ * for the provided language locale.
+ *
+ * @param response
+ * @param locale
+ * @returns {*}
+ */
+export const filterResponse = ( response, locale ) => {
+  const filtered = response;
+  filtered.hits.hits = filtered.hits.hits.filter( ( hit ) => {
+    const item = hit._source;
+    if ( item.type !== 'video' ) return true;
+    // Try to find a matching unit
+    return !!item.unit.find( ( unit ) => {
+      if ( unit.language.locale !== locale ) return false;
+      // Try to find a matching source
+      return !!unit.source.find( ( source ) => {
+        if ( source.stream && source.stream.url ) return true;
+        if ( source.streamUrl && source.streamUrl.length > 0 ) {
+          // Try to find a non empty streamUrl url
+          return !!source.streamUrl.find( streamUrl => !!streamUrl.url );
+        }
+        return false;
+      } );
+    } );
+  } );
+  return filtered;
+};
+
 export const ScrollToTop = () => {
   window.scrollTo( 0, 0 );
   return null;


### PR DESCRIPTION
TEMPORARY FIX:
Added a filter function that is called on the raw response from ElasticSearch. It removes any video documents that don't have stream URLs in the specified language locale.
Applied filter function on redux search action.
Applied filter function on recents api request response.